### PR TITLE
feat: dust extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 This repository contains CrashOverride Terraform modules:
 
 - [AWS Role](./aws/role)
+- [Dust Extension](./aws/dust)

--- a/aws/dust/.terraform-docs.yml
+++ b/aws/dust/.terraform-docs.yml
@@ -1,0 +1,4 @@
+sections:
+  hide:
+    - requirements
+    - modules

--- a/aws/dust/README.md
+++ b/aws/dust/README.md
@@ -1,0 +1,46 @@
+# CrashOverride Dust Extension
+
+This module can be used to query CrashOverride dust extension ARN
+to be as a lambda layer.
+
+## Example
+
+```terraform
+module "dust" {
+  source = "github.com/crashappsec/terraform-modules//aws/dust?ref=main"
+}
+resource "aws_lambda_function" "example" {
+  filename      = "function.zip"
+  function_name = "example"
+  layers        = [module.dust.arn]
+  ...
+}
+```
+
+See below for all outputs.
+
+## Providers
+
+| Name                                                | Version |
+| --------------------------------------------------- | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws)    | n/a     |
+| <a name="provider_http"></a> [http](#provider_http) | n/a     |
+
+## Resources
+
+| Name                                                                                                        | Type        |
+| ----------------------------------------------------------------------------------------------------------- | ----------- |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [http_http.arn](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http)       | data source |
+
+## Inputs
+
+| Name                                                            | Description                                     | Type     | Default                               | Required |
+| --------------------------------------------------------------- | ----------------------------------------------- | -------- | ------------------------------------- | :------: |
+| <a name="input_url_prefix"></a> [url_prefix](#input_url_prefix) | URL prefix where to query to dust extension ARN | `string` | `"https://dl.crashoverride.run/dust"` |    no    |
+
+## Outputs
+
+| Name                                         | Description                                                         |
+| -------------------------------------------- | ------------------------------------------------------------------- |
+| <a name="output_arn"></a> [arn](#output_arn) | Latest ARN of the dust extension layer for the AWS provider region. |

--- a/aws/dust/README.md
+++ b/aws/dust/README.md
@@ -35,9 +35,10 @@ See below for all outputs.
 
 ## Inputs
 
-| Name                                                            | Description                                     | Type     | Default                               | Required |
-| --------------------------------------------------------------- | ----------------------------------------------- | -------- | ------------------------------------- | :------: |
-| <a name="input_url_prefix"></a> [url_prefix](#input_url_prefix) | URL prefix where to query to dust extension ARN | `string` | `"https://dl.crashoverride.run/dust"` |    no    |
+| Name                                                                                 | Description                                             | Type     | Default                               | Required |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------- | -------- | ------------------------------------- | :------: |
+| <a name="input_extension_version"></a> [extension_version](#input_extension_version) | Version override. Otherwise defaults to latest version. | `string` | `null`                                |    no    |
+| <a name="input_url_prefix"></a> [url_prefix](#input_url_prefix)                      | URL prefix where to query to dust extension ARN         | `string` | `"https://dl.crashoverride.run/dust"` |    no    |
 
 ## Outputs
 

--- a/aws/dust/main.tf
+++ b/aws/dust/main.tf
@@ -1,0 +1,52 @@
+/**
+ * # CrashOverride Dust Extension
+ *
+ * This module can be used to query CrashOverride dust extension ARN
+ * to be as a lambda layer.
+ *
+ * ## Example
+ *
+ * ```terraform
+ * module "dust" {
+ *   source = "github.com/crashappsec/terraform-modules//aws/dust?ref=main"
+ * }
+ * resource "aws_lambda_function" "example" {
+ *   filename      = "function.zip"
+ *   function_name = "example"
+ *   layers        = [module.dust.arn]
+ *   ...
+ * }
+ * ```
+ *
+ * See below for all outputs.
+ */
+
+terraform {
+  required_providers {
+    aws  = {}
+    http = {}
+  }
+}
+
+data "aws_region" "current" {}
+
+data "http" "arn" {
+  url = "${var.url_prefix}/${data.aws_region.current.name}/extension.arn"
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 200
+      error_message = "Invalid status code"
+    }
+  }
+}
+
+variable "url_prefix" {
+  type        = string
+  description = "URL prefix where to query to dust extension ARN"
+  default     = "https://dl.crashoverride.run/dust"
+}
+
+output "arn" {
+  value       = trimspace(data.http.arn.response_body)
+  description = "Latest ARN of the dust extension layer for the AWS provider region."
+}

--- a/aws/dust/main.tf
+++ b/aws/dust/main.tf
@@ -40,13 +40,31 @@ data "http" "arn" {
   }
 }
 
+locals {
+  latest_arn     = trimspace(data.http.arn.response_body)
+  latest_parts   = split(":", local.latest_arn)
+  i              = length(local.latest_parts) - 1
+  layer_parts    = slice(local.latest_parts, 0, local.i)
+  latest_version = local.latest_parts[local.i]
+  version        = coalesce(var.extension_version, local.latest_version)
+  version_parts  = concat(local.layer_parts, [local.version])
+  version_arn    = join(":", local.version_parts)
+}
+
 variable "url_prefix" {
   type        = string
   description = "URL prefix where to query to dust extension ARN"
   default     = "https://dl.crashoverride.run/dust"
 }
 
+variable "extension_version" {
+  type        = string
+  nullable    = true
+  default     = null
+  description = "Version override. Otherwise defaults to latest version."
+}
+
 output "arn" {
-  value       = trimspace(data.http.arn.response_body)
+  value       = local.version_arn
   description = "Latest ARN of the dust extension layer for the AWS provider region."
 }


### PR DESCRIPTION
Chalk Dust extension allows non-docker lambdas to run `chalk env` on cold-start of the function. If the zip file was chalked with:

```sh
chalk insert function.zip --inject-binary-into-zip
```

That will include these files in the lambda function:

* `chalk` - chalk binary itself
* `chalk.json` - chalk mark

Running `chalk env` will be able to report chalk mark metadata along with the metadata where the lambda was deployed hence allowing to correlate function build metadata with deployment, same chalk already does for docker functions.

In order to install dust extension the layer ARN cannot be dynamically queried hence this module is meant to provide easy way of referencing dust extension layer ARN for when lambdas are deployed via terraform.